### PR TITLE
Composer support as a gateway to Heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+composer.phar
+vendor/
+
+# Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+# composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "alexpgates/felix",
+    "description": "A quick and dirty way to manage SMS groups using PHP and Twilio.",
+    "authors": [
+        {
+            "name": "Alex Gates",
+            "email": "alex@whatcheer.com"
+        }
+    ],
+    "require": {
+			"twilio/sdk": "~3.12.0"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,76 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "d2ce9b1b9f6ecc82e996a14e1c5991ec",
+    "packages": [
+        {
+            "name": "twilio/sdk",
+            "version": "3.12.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twilio/twilio-php.git",
+                "reference": "510fad9a9be2d7b68df7b5ff443711cbbf873068"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twilio/twilio-php/zipball/510fad9a9be2d7b68df7b5ff443711cbbf873068",
+                "reference": "510fad9a9be2d7b68df7b5ff443711cbbf873068",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.1"
+            },
+            "require-dev": {
+                "mockery/mockery": ">=0.7.2",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Services_Twilio": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Burke",
+                    "email": "kevin@twilio.com"
+                },
+                {
+                    "name": "Kyle Conroy",
+                    "email": "kyle+pear@twilio.com"
+                }
+            ],
+            "description": "A PHP wrapper for Twilio's API",
+            "homepage": "http://github.com/twilio/twilio-php",
+            "keywords": [
+                "api",
+                "sms",
+                "twilio"
+            ],
+            "time": "2014-01-30 15:53:31"
+        }
+    ],
+    "packages-dev": [
+
+    ],
+    "aliases": [
+
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": [
+
+    ],
+    "platform": [
+
+    ],
+    "platform-dev": [
+
+    ]
+}

--- a/settings.php
+++ b/settings.php
@@ -3,27 +3,40 @@
 // You must fill in these variables.
 
 // Set our AccountSid and AuthToken from twilio.com/user/account
-$AccountSid = '';
-$AuthToken = '';
+$AccountSid = $_ENV['TWILIO_ACCOUNT_SID'];
+$AuthToken = $_ENV['TWILIO_AUTH_TOKEN'];
 
 /* Your Twilio Number or Outgoing Caller ID (Note: Don't use +1) */
-$caller_id = '5554445555';
+$caller_id = $_ENV['TWILIO_PHONE_NUMBER'];
 
 // Phone number of group administrator. This number will receive notifications when people join. (Note: USE +1.)
-$group_admin_number = '+13334445555';
+$group_admin_number = $_ENV['ADMIN_PHONE_NUMBER'];
 
 // Name of the group administrator. This is used in the welcome text for new members
-$group_admin_name = '';
-
+$group_admin_name = $_ENV['ADMIN_NAME'];
 
 // MYSQL settings
-$mysql_host = '';
 
-$mysql_user = '';
-
-$mysql_pass = '';
-
-$mysql_database_name = '';
+if(array_key_exists('MYSQL_DATABASE_URL', $_ENV)) {
+	$url = parse_url(getenv("MYSQL_DATABASE_URL"));
+	$mysql_host = $url["host"];
+	$mysql_user = $url["user"];
+	$mysql_pass = $url["pass"];
+	$mysql_database_name = substr($url["path"],1);
+}
+else if(array_key_exists('CLEARDB_DATABASE_URL', $_ENV)) {
+	$url = parse_url(getenv("CLEARDB_DATABASE_URL"));
+	$mysql_host = $url["host"];
+	$mysql_user = $url["user"];
+	$mysql_pass = $url["pass"];
+	$mysql_database_name = substr($url["path"],1);
+}
+else {
+	$mysql_host = '';
+	$mysql_user = '';
+	$mysql_pass = '';
+	$mysql_database_name = '';
+}
 
 
 // no need to edit anything below this line

--- a/sms.php
+++ b/sms.php
@@ -1,5 +1,5 @@
 <?php
-require "Services/Twilio.php";
+require 'vendor/autoload.php';
 require "settings.php";
 
 // grab the number of the number that is texting in


### PR DESCRIPTION
Hey Alex!

So, I added composer support to Felix, since that is required to enable Heroku support.

Additionally, I made the settings file default to using environment variables to populate configuration first.  Doesn't change the option for overwriting in a specific install, just makes it pull from the environment by if you don't change anything.

Feel free to reject this, or isolate it on another branch.  I'm still working on converting to mysqli for PHP 5.5 support. 
